### PR TITLE
Explicit initialization

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -1,15 +1,14 @@
 ################### C compiler ########################
 
-# C compiler to use
-CC=gcc
-
 # Flags for $(CC)
-CFLAGS=-O -g -Wall
+CFLAGS?=-O -g -Wall
 
 ################### Java compiler #####################
 
+JAVACFLAGS?=-g
+
 # Java compiler to use
-JAVAC=javac -g
+JAVAC=javac
 
 ################### JNI interface #####################
 
@@ -26,7 +25,7 @@ JDKHOME=/usr/lib/jvm/java-8-openjdk-amd64
 ARCH=amd64
 
 # Where to find the JNI include files (for compiling the OCaml-JNI C stubs)
-JNIINCLUDES=-I$(JDKHOME)/include -I$(JDKHOME)/include/linux
+JNIINCLUDES?=-I$(JDKHOME)/include -I$(JDKHOME)/include/linux
 
 # The library to link with to get the JNI
 JNILIBS=-ljvm

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,26 +1,36 @@
 include ../Makefile.config
 
-OCAMLC=ocamlc -g
-OCAMLOPT=ocamlopt
-OCAMLDEP=ocamldep
-OCAMLLIB=`ocamlc -where`
+OCAMLFIND=ocamlfind
+OCAMLC=$(OCAMLFIND) ocamlc -g
+OCAMLOPT=$(OCAMLFIND) ocamlopt
+OCAMLDEP=$(OCAMLFIND) ocamldep
+OCAMLLIB=`$(OCAMLC) -where`
 CAMLJAVALIB=$(OCAMLLIB)/camljava
 
-all: jni.cma jni.cmxa javaclasses
-byte: jni.cma javaclasses
+JNICFLAGS=-ccopt "$(JNILIBOPTS)" -cclib "$(JNILIBS)"
+
+JAVA_FILES=$(wildcard fr/inria/caml/camljava/*.java)
+# Incomplete list of .class files
+JAVA_CLASSES=$(JAVA_FILES:.java=.class)
+
+all: jni.cma jni.cmxa camljava.jar
+byte: jni.cma camljava.jar
 
 install:
 	mkdir -p $(CAMLJAVALIB)
-	cp jni.cma jni.cmi $(wildcard jni.cmxa jni.a) libcamljni.a jni.mli $(CAMLJAVALIB)
-	jar cf $(CAMLJAVALIB)/camljava.jar fr/inria/caml/camljava/*.class
+	cp jni.cma jni.cmi camljava.jar $(wildcard jni.cmxa jni.a) libcamljni.a jni.mli $(CAMLJAVALIB)
+
+camljava.jar: $(JAVA_CLASSES)
+	jar cf $@ fr/inria/caml/camljava/*.class
+
+clean::
+	rm -f camljava.jar
 
 jni.cma: jni.cmo libcamljni.a
-	$(OCAMLC) -linkall -a -o jni.cma -custom jni.cmo \
-            -ccopt "$(JNILIBOPTS)" -cclib -lcamljni -cclib "$(JNILIBS)"
+	$(OCAMLC) -linkall -a -o jni.cma -custom jni.cmo $(JNICFLAGS) -cclib -lcamljni
 
 jni.cmxa: jni.cmx libcamljni.a
-	$(OCAMLOPT) -linkall -a -o jni.cmxa jni.cmx \
-            -ccopt "$(JNILIBOPTS)" -cclib -lcamljni -cclib "$(JNILIBS)"
+	$(OCAMLOPT) -linkall -a -o jni.cmxa jni.cmx $(JNICFLAGS) -cclib -lcamljni
 
 libcamljni.a: jnistubs.o
 	rm -f libcamljni.a
@@ -40,8 +50,8 @@ clean::
 
 beforedepend:: jni.ml
 
-javaclasses:
-	$(JAVAC) fr/inria/caml/camljava/*.java
+$(JAVA_CLASSES): $(JAVA_FILES)
+	$(JAVAC) $(JAVACFLAGS) $(JAVA_FILES)
 
 clean::
 	rm -f fr/inria/caml/camljava/*.class
@@ -52,7 +62,7 @@ clean::
 .SUFFIXES: .ml .mli .cmo .cmi .cmx
 
 .c.o:
-	$(CC) -c $(CFLAGS) $(JNIINCLUDES) -I$(OCAMLLIB) $*.c
+	$(OCAMLOPT) -c -ccopt "$(CFLAGS) $(JNIINCLUDES)" $*.c
 
 .ml.cmo:
 	$(OCAMLC) -c $*.ml

--- a/lib/fr/inria/caml/camljava/Caml.java
+++ b/lib/fr/inria/caml/camljava/Caml.java
@@ -1,0 +1,14 @@
+package fr.inria.caml.camljava;
+
+public class Caml {
+	private Caml() {}
+
+	/**
+	 * OCaml startup function
+	 * This function (or Jni.init on the OCaml side)
+	 *  must be called before any other camljava functions
+	 * Note: Java strings (with their custom UTF-8)
+	 *  are passed to OCaml without convertion
+	 */
+	public static native void startup(String[] argv);
+}

--- a/lib/jni.mli
+++ b/lib/jni.mli
@@ -360,10 +360,3 @@ external set_double_array_element: obj -> int -> float -> unit
 (* Auxiliaries for Java->OCaml callbacks *)
 
 val wrap_object: < .. > -> obj
-
-(* Init from ocaml
-  Other functions in this module will crash
-    if this function or Caml.startup (java) is not called once first
-  Must not be called if Caml.startup is called from java *)
-(* Takes the path to camljava.jar *)
-val init: unit -> unit

--- a/lib/jni.mli
+++ b/lib/jni.mli
@@ -361,3 +361,9 @@ external set_double_array_element: obj -> int -> float -> unit
 
 val wrap_object: < .. > -> obj
 
+(* Init from ocaml
+  Other functions in this module will crash
+    if this function or Caml.startup (java) is not called once first
+  Must not be called if Caml.startup is called from java *)
+(* Takes the path to camljava.jar *)
+val init: unit -> unit

--- a/lib/jni.mlp
+++ b/lib/jni.mlp
@@ -21,6 +21,21 @@ external set_string_auto_conv: bool -> unit = "camljava_set_strconv"
 external init: string -> unit = "camljava_Init"
 external shutdown: unit -> unit = "camljava_Shutdown"
 
+let _ =
+  let libpath = "%PATH%" in
+  let sep =
+    match Sys.os_type with
+      "Unix" -> ":"
+    | "Win32" -> ";"
+    | _ -> assert false in
+  let path =
+    try
+      Sys.getenv "CLASSPATH" ^ sep ^ libpath
+    with Not_found ->
+      libpath in
+  init path;
+  at_exit shutdown
+
 type obj
 
 external get_null: unit -> obj = "camljava_GetNull"
@@ -29,9 +44,18 @@ let null = get_null()
 
 exception Null_pointer
 
+let _ = Callback.register_exception "camljava_null_pointer" Null_pointer
+
 exception Exception of obj
 
+let _ = Callback.register "camljava_raise_exception"
+          (fun obj -> raise (Exception obj))
+
 external register_natives: unit -> unit = "camljava_RegisterNatives"
+
+let _ = register_natives()
+
+let _ = Callback.register "Oo.new_method" Oo.new_method
 
 (* String operations *)
 
@@ -43,6 +67,8 @@ let null_string = ""
 let is_null_string s = s == null_string
 
 external register_null_string: string -> unit = "camljava_RegisterNullString"
+
+let _ = register_null_string null_string
 
 (* Class operations *)
 
@@ -339,42 +365,11 @@ external is_same_object: obj -> obj -> bool = "camljava_IsSameObject"
 external wrap_caml_object : < .. > -> int64 = "camljava_WrapCamlObject"
 
 let callback_class =
-  lazy (
-    let callback_class = find_class "fr/inria/caml/camljava/Callback" in
-    callback_class, get_methodID callback_class "<init>" "(J)V")
-
+  find_class "fr/inria/caml/camljava/Callback"
+let callback_init =
+  get_methodID callback_class "<init>" "(J)V"
 let wrap_object camlobj =
-  let callback_class, callback_init = Lazy.force callback_class in
   let javaobj = alloc_object callback_class in
   call_nonvirtual_void_method javaobj callback_class callback_init
                               [|Long (wrap_caml_object camlobj)|];
   javaobj
-
-(* Init *)
-
-let stubs_init () =
-  Callback.register_exception "camljava_null_pointer" Null_pointer;
-  Callback.register "camljava_raise_exception"
-    (fun obj -> raise (Exception obj));
-  register_natives();
-  Callback.register "Oo.new_method" Oo.new_method;
-  register_null_string null_string
-
-let init () =
-  let libpath = "%PATH%" in
-  let sep =
-    match Sys.os_type with
-      "Unix" -> ":"
-    | "Win32" -> ";"
-    | _ -> assert false in
-  let path =
-    try
-      Sys.getenv "CLASSPATH" ^ sep ^ libpath
-    with Not_found ->
-      libpath in
-  stubs_init ();
-  init path;
-  at_exit shutdown
-
-let () =
-  Callback.register "camljava_stubs_init" stubs_init

--- a/lib/jni.mlp
+++ b/lib/jni.mlp
@@ -21,21 +21,6 @@ external set_string_auto_conv: bool -> unit = "camljava_set_strconv"
 external init: string -> unit = "camljava_Init"
 external shutdown: unit -> unit = "camljava_Shutdown"
 
-let _ =
-  let libpath = "%PATH%" in  
-  let sep =
-    match Sys.os_type with
-      "Unix" -> ":"
-    | "Win32" -> ";"
-    | _ -> assert false in
-  let path =
-    try
-      Sys.getenv "CLASSPATH" ^ sep ^ libpath
-    with Not_found ->
-      libpath in
-  init path;
-  at_exit shutdown
-
 type obj
 
 external get_null: unit -> obj = "camljava_GetNull"
@@ -44,18 +29,9 @@ let null = get_null()
 
 exception Null_pointer
 
-let _ = Callback.register_exception "camljava_null_pointer" Null_pointer
-
 exception Exception of obj
 
-let _ = Callback.register "camljava_raise_exception"
-          (fun obj -> raise (Exception obj))
-
 external register_natives: unit -> unit = "camljava_RegisterNatives"
-
-let _ = register_natives()
-
-let _ = Callback.register "Oo.new_method" Oo.new_method
 
 (* String operations *)
 
@@ -67,8 +43,6 @@ let null_string = ""
 let is_null_string s = s == null_string
 
 external register_null_string: string -> unit = "camljava_RegisterNullString"
-
-let _ = register_null_string null_string
 
 (* Class operations *)
 
@@ -365,11 +339,42 @@ external is_same_object: obj -> obj -> bool = "camljava_IsSameObject"
 external wrap_caml_object : < .. > -> int64 = "camljava_WrapCamlObject"
 
 let callback_class =
-  find_class "fr/inria/caml/camljava/Callback"
-let callback_init =
-  get_methodID callback_class "<init>" "(J)V"
+  lazy (
+    let callback_class = find_class "fr/inria/caml/camljava/Callback" in
+    callback_class, get_methodID callback_class "<init>" "(J)V")
+
 let wrap_object camlobj =
+  let callback_class, callback_init = Lazy.force callback_class in
   let javaobj = alloc_object callback_class in
   call_nonvirtual_void_method javaobj callback_class callback_init
                               [|Long (wrap_caml_object camlobj)|];
   javaobj
+
+(* Init *)
+
+let stubs_init () =
+  Callback.register_exception "camljava_null_pointer" Null_pointer;
+  Callback.register "camljava_raise_exception"
+    (fun obj -> raise (Exception obj));
+  register_natives();
+  Callback.register "Oo.new_method" Oo.new_method;
+  register_null_string null_string
+
+let init () =
+  let libpath = "%PATH%" in
+  let sep =
+    match Sys.os_type with
+      "Unix" -> ":"
+    | "Win32" -> ";"
+    | _ -> assert false in
+  let path =
+    try
+      Sys.getenv "CLASSPATH" ^ sep ^ libpath
+    with Not_found ->
+      libpath in
+  stubs_init ();
+  init path;
+  at_exit shutdown
+
+let () =
+  Callback.register "camljava_stubs_init" stubs_init

--- a/lib/jnistubs.c
+++ b/lib/jnistubs.c
@@ -1,8 +1,10 @@
 #include <stddef.h>
 #include <string.h>
+#include <stdio.h>
 #include <jni.h>
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
+
 #include <caml/alloc.h>
 #include <caml/custom.h>
 #include <caml/fail.h>
@@ -694,6 +696,9 @@ value camljava_SetByteArrayRegion(value vstr, value vsrcidx,
 
 value camljava_Init(value vclasspath)
 {
+#ifdef ANDROID
+  failwith("Jni.init: Not available on Android");
+#else
   JavaVMInitArgs vm_args;
   JavaVMOption options[1];
   int retcode;
@@ -715,6 +720,7 @@ value camljava_Init(value vclasspath)
   stat_free(classpath);
   if (retcode < 0) failwith("Java.init");
   init_threading(); // by O'Jacare
+#endif
   return Val_unit;
 }
 
@@ -722,6 +728,35 @@ value camljava_Shutdown(value unit)
 {
   (*jvm)->DestroyJavaVM(jvm);
   return Val_unit;
+}
+
+// Implementation of Caml.startup
+// Cannot be registered with camljava_RegisterNatives
+//  because it may be called before camljava_RegisterNatives
+void Java_fr_inria_caml_camljava_Caml_startup(JNIEnv * env, jclass cls, jobjectArray jargv)
+{
+  jenv = env;
+  init_threading();
+  {
+    jsize argc = (*env)->GetArrayLength(env, jargv);
+    // Dup jargv before because
+    // caml_startup keep a reference to argv for ever
+    char **argv;
+    jsize i;
+    argv = malloc(sizeof(char*) * ((*env)->GetArrayLength(env, jargv) + 1));
+    for (i = 0; i < argc; i++)
+    {
+      jbyteArray arg = (*env)->GetObjectArrayElement(env, jargv, i);
+      argv[i] = strdup((*env)->GetStringUTFChars(env, arg, NULL));
+      (*env)->ReleaseStringUTFChars(env, arg, argv[i]);
+    }
+    argv[i] = NULL;
+    caml_startup(argv);
+  }
+  {
+    value *stubs_init = caml_named_value("camljava_stubs_init");
+    caml_callback(*stubs_init, Val_unit);
+  }
 }
 
 /****************** Object operations ********************/

--- a/lib/jnistubs.c
+++ b/lib/jnistubs.c
@@ -11,7 +11,7 @@
 #include <caml/callback.h>
 
 static JavaVM * jvm;
-static JNIEnv * jenv;
+static JNIEnv * jenv = NULL;
 
 #define Val_jboolean(b) ((b) == JNI_FALSE ? Val_false : Val_true)
 #define Jboolean_val(v) (Val_bool(v) ? JNI_TRUE : JNI_FALSE)
@@ -705,6 +705,9 @@ value camljava_Init(value vclasspath)
   char * classpath;
   char * setclasspath = "-Djava.class.path=";
 
+  /* Already initialized, eg. with Caml.startup */
+  if (jenv != NULL)
+    return Val_unit;
   /* Set the class path */
   classpath = 
     stat_alloc(strlen(setclasspath) + string_length(vclasspath) + 1);
@@ -752,10 +755,6 @@ void Java_fr_inria_caml_camljava_Caml_startup(JNIEnv * env, jclass cls, jobjectA
     }
     argv[i] = NULL;
     caml_startup(argv);
-  }
-  {
-    value *stubs_init = caml_named_value("camljava_stubs_init");
-    caml_callback(*stubs_init, Val_unit);
   }
 }
 


### PR DESCRIPTION
Hi,

In order to use this lib when the JVM is already running (eg. main is in Java, OCaml code is loaded as a library) the initialization must be explicit.

I add a binding for `caml_startup` from java: `Caml.startup(String[])`

I also made some noise with the Makefiles.
  